### PR TITLE
Mosesoak

### DIFF
--- a/lib/flashsdk/mxmlc.rb
+++ b/lib/flashsdk/mxmlc.rb
@@ -119,10 +119,8 @@ module FlashSDK
     set :executable, :mxmlc
 
     def execute
-      start = Time.now
-      super
-      duration = (Time.now - start).seconds
-      Sprout.stdout.puts "[MXMLC] Compilation complete in #{duration} seconds." unless use_fcsh?
+      duration = Benchmark.measure { super }
+      Sprout.stdout.puts "[MXMLC] Compilation complete in #{duration.real} seconds." unless use_fcsh?
     end
 
     def use_fcsh?

--- a/lib/flashsdk/mxmlc.rb
+++ b/lib/flashsdk/mxmlc.rb
@@ -1,3 +1,4 @@
+require 'benchmark'
 module FlashSDK
 
   ##


### PR DESCRIPTION
Hi Luke, I was getting 

rake aborted!
undefined method `seconds' for 4.527477:Float

I switched to the benchmark utility (http://www.ruby-doc.org/stdlib/libdoc/benchmark/rdoc/index.html), we've had better luck with that here at Animoto.

cheers
