### PR TITLE
adl

### DIFF
--- a/lib/flashsdk/adl.rb
+++ b/lib/flashsdk/adl.rb
@@ -40,6 +40,12 @@ module FlashSDK
   end
 end
 
+def adl *args, &block
+  exe = FlashSDK::ADL.new
+  exe.to_rake(*args, &block)
+  exe
+end
+
 ##
 # TODO: This should NOT be here!
 # This is preventing that method from working


### PR DESCRIPTION
Referencing the adl executable from a rakefile wasn't working for me. adl.rb appeared to missing the link to the tool itself so I added one and things started running.
